### PR TITLE
fix elasticsearch query builder when using $in in a nested query such as $and/$or

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 clover.xml
 build
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ public function handle(ServerRequestInterface $request): ResponseInterface
 
 You can mix and nest queries:
 
-| url query | select |
-|-----------|-----------|
-| ?q={"id":{"$not":1},"$or":[{"id":2},{"id":"3"}],"$and":[{"id":2},{"name":"test"}]} | WHERE "id" != '1' AND ("id" = '2' OR "id" = '3') AND ("id" = '2' AND "name" = 'test') |
-| ?q={"$or":[{"$and":[{"id":1},{"name":"test"}]},{"id":{"$not":1}},{"name":"test"}]} | WHERE (("id" = '1' AND "name" = 'test') OR "id" != '1' OR "name" = 'test') |
+| url query                                                                           | select |
+|-------------------------------------------------------------------------------------|-----------|
+| ?q={"id":{"$not":1},"$or":[{"id":2},{"id":"3"}],"$and":[{"id":2},{"name":"test"}]}  | WHERE "id" != '1' AND ("id" = '2' OR "id" = '3') AND ("id" = '2' AND "name" = 'test') |
+| ?q={"$or":[{"$and":[{"id":1},{"name":"test"}]},{"id":{"$not":1}},{"name":"test"}]}  | WHERE (("id" = '1' AND "name" = 'test') OR "id" != '1' OR "name" = 'test') |
+| ?q={"$and": [{"name":"john"},{"likes": {"$in": ["facebook", "twitter", "instagram"]}}]} | WHERE ("name" = 'john' AND "likes" IN ('facebook', 'twitter', 'instagram')) |
 
 #### Hint examples:
 

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,10 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/ElasticSearchBuilder.php
+++ b/src/ElasticSearchBuilder.php
@@ -110,7 +110,7 @@ final class ElasticSearchBuilder implements BuilderInterface
         $op      = key($value);
 
         if (in_array($op, BuilderInterface::OP_LOGIC)) {
-            return $this->parseLogic($key, $op, $opValue);
+            return $this->parseLogic($key, $op, $opValue, $withoutOperator);
         }
 
         if (in_array($op, BuilderInterface::OP_CONDITIONAL)) {
@@ -125,18 +125,24 @@ final class ElasticSearchBuilder implements BuilderInterface
      *
      * @param mixed $value
      */
-    private function parseLogic(string $key, string $op, $value): array
+    private function parseLogic(string $key, string $op, $value, bool $withoutOperator = false): array
     {
         if ($op === BuilderInterface::OP_NOT) {
-            return ['must_not' => ['term' => [$key => $value]]];
+            $params = ['term' => [$key => $value]];
+
+            return $withoutOperator ? $params : ['must_not' => $params];
         }
 
         if ($op === BuilderInterface::OP_IN) {
-            return ['filter' => ['terms' => [$key => $value]]];
+            $params = ['terms' => [$key => $value]];
+
+            return $withoutOperator ? $params : ['filter' => $params]; // filter or must?
         }
 
         if ($op === BuilderInterface::OP_NOT_IN) {
-            return ['must_not' => ['terms' => [$key => $value]]];
+            $params = ['terms' => [$key => $value]];
+
+            return $withoutOperator ? $params : ['must_not' => $params]; // filter or must?
         }
 
         // At this point, should only be BuilderInterface::OP_LIKE . No if to keep PHPUnit happy

--- a/test/ElasticSearchBuilderTest.php
+++ b/test/ElasticSearchBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Los\UqlTests;
+
+use Los\Uql\ElasticSearchBuilder;
+use PHPUnit\Framework\TestCase;
+use Laminas\Diactoros\ServerRequest;
+
+class ElasticSearchBuilderTest extends TestCase
+{
+    private ElasticSearchBuilder $builder;
+
+    public function testSimpleIn()
+    {
+        $request = new ServerRequest();
+        $request = $request->withQueryParams(['q' => '{"names": {"$in":["john", "doe"]}}']);
+        $query = $this->builder->fromRequest($request);
+        $this->assertSame([
+            'body' => [
+                'query' => [
+                    'constant_score' => [
+                        'filter' => [
+                            'bool' => [
+                                'filter' => [
+                                    'terms' => [
+                                        'names' => [
+                                            'john',
+                                            'doe',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $query);
+    }
+
+    public function testAndWithNestedIn()
+    {
+        $request = new ServerRequest();
+        $request = $request->withQueryParams(['q' => '{"$and": [{"name":"john"},{"likes": {"$in": ["facebook", "twitter", "instagram"]}}]}']);
+        $query = $this->builder->fromRequest($request);
+        $this->assertSame([
+            'body' => [
+                'query' => [
+                    'constant_score' => [
+                        'filter' => [
+                            'bool' => [
+                                'must' => [
+                                    ['term' =>[ 'name' => 'john']],
+                                    [
+                                        'terms' => [
+                                            'likes' => [
+                                                'facebook',
+                                                'twitter',
+                                                'instagram',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $query);
+    }
+
+    protected function setUp() : void
+    {
+        $this->builder = new ElasticSearchBuilder();
+    }
+}

--- a/test/ZendDbBuilderTest.php
+++ b/test/ZendDbBuilderTest.php
@@ -15,7 +15,7 @@ class ZendDbBuilderTest extends TestCase
     /** @var ZendDbBuilder */
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ZendDbBuilder(new Select('test'));
     }
@@ -246,6 +246,15 @@ class ZendDbBuilderTest extends TestCase
         $request = $request->withQueryParams(['h' => '{"$skip":100}']);
         $select = $this->builder->fromRequest($request);
         $this->assertSame('SELECT "test".* FROM "test" OFFSET \'100\'', $this->createString($select));
+    }
+
+    public function testAndWithNestedIn()
+    {
+        $request = new ServerRequest();
+        $request = $request->withQueryParams(['q' => '{"$and": [{"name":"john"},{"likes": {"$in": ["facebook", "twitter", "instagram"]}}]}']);
+        $select = $this->builder->fromRequest($request);
+        $this->assertSame(1, $select->where->count());
+        $this->assertSame('SELECT "test".* FROM "test" WHERE ("name" = \'john\' AND "likes" IN (\'facebook\', \'twitter\', \'instagram\'))', $this->createString($select));
     }
 
     private function createString(Select $select) : string


### PR DESCRIPTION
The following query was converting the $in into `filters` key inside a `must` array, which is not the correct syntax for `must` query in ElasticSearch. 

Ex: 
`['q' => '{"$and": [{"name":"john"},{"likes": {"$in": ["facebook", "twitter", "instagram"]}}]}']` 

Result:
```{
   "body":{
      "query":{
         "constant_score":{
            "filter":{
               "bool":{
                  "must":[
                     {
                        "term":{
                           "name":"johh"
                        }
                     },
                     {
                        "filter":{
                           "terms":{
                              "likes":[
                                 "facebook",
                                 "twitter"
                              ]
                           }
                        }
                     }
                  ]
               }
            }
         }
      }
   }
}```

Now, it is correct as you can see in the test cases.